### PR TITLE
docs: notas de persistencia WSL/Linux no README

### DIFF
--- a/.kiro/steering/project-knowledge.md
+++ b/.kiro/steering/project-knowledge.md
@@ -226,3 +226,33 @@ Padrão comum dos fluxos SAML (`google`/`azure`):
 - 2026-06-26 — `gh` CLI instalado via winget (GitHub.cli 2.95.0). Após instalar, recarregar PATH em novas sessões
   (`$env:Path = [Environment]::GetEnvironmentVariable('Path','Machine')+';'+[Environment]::GetEnvironmentVariable('Path','User')`).
   Falta `gh auth login` (passo interativo do usuário). Push continua por SSH; `gh` é só para a API (criar PR).
+- 2026-06-26 — PR da v3 aberto (#10) a partir da branch `feat/v3-typescript-playwright-oidc`; CI `build` passou. O
+  `main` é PROTEGIDO: exige aprovação de revisão (`REVIEW_REQUIRED`) e o auto-merge está DESABILITADO no repo →
+  merge só após revisão humana (não usar `--admin` p/ burlar). Release no ECR dispara só por push de tag (merge não
+  publica). Commit exigiu identidade git: definida LOCAL no repo via conta GitHub (noreply), sem tocar config global.
+- 2026-06-26 — v3.0.0 MERGED no `main` (PR #10, merge commit `1057f2f`) e branch deletada; repo local sincronizado.
+  Imagem NÃO publicada (release no ECR só por push de tag → `git tag v3.0.0 && git push origin v3.0.0`; cuidado com
+  `:latest` por ser breaking). Dependabot abriu PRs p/ as actions antigas (build-push/login/setup-buildx) que ficaram
+  redundantes após a modernização dos workflows — fechar. `.kiro/steering/project-knowledge.md` segue versionado no repo.
+- 2026-06-26 — v3.0.0 PUBLICADA: tags do repo seguem padrão SEM `v` (ex.: `1.2.8`, `3.0.0`); a tag vira o sufixo da
+  imagem (`RELEASE_VERSION=github.ref_name`). Push da tag `3.0.0` disparou o workflow "Build and Push Oni Image"
+  (sucesso) → publicou `public.ecr.aws/dnxbrasil/oni-sso:3.0.0` e `:latest`. PRs/alertas do Dependabot p/ deps removidas
+  (uuid, fast-xml-parser, puppeteer/tar-fs/ws) falham e estão obsoletos → fechar.
+- 2026-06-26 — Limpeza pós-v3: fechados os PRs npm obsoletos do Dependabot (#6 fast-xml-parser, #7 uuid, #8 ws/puppeteer,
+  #9 tar-fs/puppeteer). Os 8 alertas de segurança auto-resolveram (0 abertos) após a v3 remover puppeteer/ws/tar-fs/uuid —
+  não foi preciso descartar manualmente. Restam abertos PRs de GitHub Actions (#11–#15: login@4, checkout@7, setup-node@6,
+  build-push@7, setup-buildx@4) — upgrades válidos a aplicar (ideal: bump direto nos workflows num único PR).
+- 2026-06-26 — Tag != Release no GitHub: o push da tag dispara o build/publish da imagem (workflow `on: push tags`),
+  mas NÃO cria entrada na aba Releases. Criar o Release (`gh release create 3.0.0 --notes ...`) é passo separado e
+  seguro (nenhum workflow em `on: release`; não rebuilda). Release 3.0.0 publicado (vira "Latest" por semver). Para
+  lançamentos futuros: `gh release create <versao> --generate-notes` cria tag + release + notas de uma vez.
+- 2026-06-26 — Persistência no Linux: a imagem roda como ROOT (HOME=/root) → perfil em `/root/.oni-sso/profiles`.
+  Docker: montar `-v "$HOME/.oni-sso:/root/.oni-sso"`. Gotcha: arquivos no host ficam root-owned (usar sudo p/ limpar,
+  ou rodar `--user $(id -u):$(id -g) -e HOME=/work -e ONI_PROFILE_DIR=/work/.oni-sso/profiles`; `/ms-playwright` é
+  world-readable, browsers rodam como não-root). Nativo: `npx playwright install --with-deps chromium`. Captcha do
+  Google em servidor sem tela: `xvfb-run -a env ONI_HEADFUL=1 ...` ou semear o perfil num desktop e copiar `~/.oni-sso`.
+- 2026-06-26 — Armadilha WSL+Docker: perfil persistente do Chromium (`user-data-dir`) NÃO funciona em mount do
+  Windows (`/mnt/c` via drvfs) — file-locking quebrado faz o launch TRAVAR antes do prompt. Sintoma: com
+  `ONI_PROFILE_DIR=/work/...` (bind no Windows) trava; sem (default `/root`, overlay Linux) funciona mas não persiste
+  (`--rm`). Solução: **volume nomeado** Docker mapeado p/ `/root/.oni-sso` (fica no ext4 da VM) ou repo no home do WSL.
+  Também: `ONI_HEADFUL=1` NÃO funciona em container (sem X server) → erro "Missing X server". Headless sempre em container.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,33 @@ when the email/password fields actually appear — on a trusted device nothing i
 * Security: the profile stores session cookies (equivalent to being logged in). Keep it private; don't use a shared dir.
 * Docker: to persist across containers, mount the profile dir as a volume, e.g. `-v $HOME/.oni-sso:/root/.oni-sso`.
 
+## WSL / Linux notes
+
+The container runs as **root** (`HOME=/root`), so the persistent profile lives at `/root/.oni-sso/profiles`.
+
+**Important (WSL):** the Chromium profile (`user-data-dir`) does **not** work on a Windows-backed mount (`/mnt/c/...` via drvfs) — file locking is broken there and the browser **hangs on launch** before any prompt. Symptom: with `ONI_PROFILE_DIR` pointing to a `/mnt/c` bind mount it freezes; with the default (`/root`, not mounted) it works but doesn't persist (`--rm`).
+
+**Recommended (persistence that works on WSL):** use a Docker **named volume** for the profile — it lives on the Linux VM filesystem (ext4), avoiding drvfs entirely:
+
+```bash
+docker volume create oni-sso-profiles
+
+docker run --rm -it \
+  -v "$PWD:/work" \
+  -v oni-sso-profiles:/root/.oni-sso \
+  public.ecr.aws/dnxbrasil/oni-sso:latest \
+  auth-azure -a "$AZURE_APP_ID_URI" -t "$AZURE_TENANT_ID" -o console
+```
+
+Run it twice — the second run should skip MFA (device remembered).
+
+Alternative: keep the repo inside the WSL home (`~/...`, ext4) instead of `/mnt/c`, then a bind mount works too.
+
+Other notes:
+- **Do not use `ONI_HEADFUL=1` in a container** — there is no X server, so a headed launch fails with "Missing X server". Containers always run headless. For first-time Google captcha seeding without a desktop, use `xvfb-run -a env ONI_HEADFUL=1 ...` (xvfb ships in the Playwright image) or seed the profile on a machine with a display and copy `~/.oni-sso`.
+- Bind mounts are written as root; on Linux either `sudo chown -R $USER ...` afterward or run with `--user "$(id -u):$(id -g)" -e HOME=/work -e ONI_PROFILE_DIR=/work/.oni-sso/profiles`.
+- If a profile got corrupted by a failed headed launch, remove it (e.g. `rm -rf .oni-sso/profiles/azure`) and re-run headless.
+
 ## Requirements
 * Runs on Node.js >= 22.12 (the published image is based on the official Playwright image). The browser flows (Google/Azure) use Playwright; AWS SSO uses the AWS SDK and needs no browser binary.
 


### PR DESCRIPTION
## Resumo
Documentação de persistência de login para **WSL/Linux** e atualização da base de conhecimento (steering).

## Mudanças
- **README — nova seção "WSL / Linux notes"**:
  - Perfil persistente do Chromium NÃO funciona em mount do Windows (`/mnt/c` via drvfs) → trava no launch
  - Solução recomendada: **volume nomeado** do Docker mapeado para `/root/.oni-sso` (fica no ext4 da VM)
  - `ONI_HEADFUL=1` não funciona em container (sem X server); alternativa `xvfb-run` ou semear perfil em desktop
  - Permissões de bind mount (root) e limpeza de perfil corrompido
- **.kiro/steering/project-knowledge.md**: lições aprendidas acumuladas da v3

Apenas documentação — sem mudança de código.
